### PR TITLE
Coveralls and JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ matrix:
       # always build this environment
       - os: linux
         dist: xenial
-        jdk: openjdk8
+        jdk: openjdk9
         env: ADDITIONAL_MAVEN_ARGS="-Pjacoco coveralls:report"
       # only on PR
       - os: linux
         dist: xenial
-        jdk: openjdk9
+        jdk: openjdk8
         if: type IN (pull_request)
       # only on PR or after merging a PR
       - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       # always build this environment
       - os: linux
         dist: xenial
-        jdk: openjdk9
+        jdk: openjdk11
         env: ADDITIONAL_MAVEN_ARGS="-Pjacoco coveralls:report"
       # only on PR
       - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       - os: linux
         dist: xenial
         jdk: openjdk8
-        if: type IN (pull_request)
+        env: ADDITIONAL_MAVEN_ARGS="-Pjacoco coveralls:report"
       # only on PR or after merging a PR
       - os: osx
         osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       - os: linux
         dist: xenial
         jdk: openjdk8
-        env: ADDITIONAL_MAVEN_ARGS="-Pjacoco coveralls:report"
+        if: type IN (pull_request)
       # only on PR or after merging a PR
       - os: osx
         osx_image: xcode10.1

--- a/com.examples.myproject/pom.xml
+++ b/com.examples.myproject/pom.xml
@@ -45,6 +45,13 @@
           <groupId>org.eluder.coveralls</groupId>
           <artifactId>coveralls-maven-plugin</artifactId>
           <version>4.3.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>javax.xml.bind</groupId>
+              <artifactId>jaxb-api</artifactId>
+              <version>2.3.1</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/com.examples.myproject/pom.xml
+++ b/com.examples.myproject/pom.xml
@@ -46,6 +46,10 @@
           <artifactId>coveralls-maven-plugin</artifactId>
           <version>4.3.0</version>
           <dependencies>
+            <!-- Explicit dep on jaxb-api to avoid problems with
+              JDK9 and later, until a new version of
+              coveralls-maven-plugin is released.
+              See also https://github.com/trautonen/coveralls-maven-plugin/issues/112-->
             <dependency>
               <groupId>javax.xml.bind</groupId>
               <artifactId>jaxb-api</artifactId>


### PR DESCRIPTION
Build by default with OpenJdk 11 to show a problem of coveralls-maven-plugin due to missing javax.xml.bind

See also https://github.com/trautonen/coveralls-maven-plugin/issues/112